### PR TITLE
Implement Gmail IMAP extensions

### DIFF
--- a/child-fetch.c
+++ b/child-fetch.c
@@ -517,6 +517,7 @@ fetch_enqueue(struct account *a, struct io *pio, struct mail *m)
 	int			 error;
 	struct tm		*tm;
 	time_t			 t;
+	const char		*tptr;
 
 	/*
 	 * Check for oversize mails. This must be first since there is no
@@ -620,6 +621,20 @@ fetch_enqueue(struct account *a, struct io *pio, struct mail *m)
 		}
 		if (error != 0)
 			log_debug3("%s: couldn't add received header", a->name);
+	}
+
+	/* Insert Gmail-specific headers. */
+	if ((tptr = find_tag(m->tags, "gmail_msgid")) != NULL) {
+		if (insert_header(m, "message-id", "X-GM-MSGID: %s", tptr) != 0)
+			log_warnx("%s: failed to add header X-GM-MSGID", a->name);
+	}
+	if ((tptr = find_tag(m->tags, "gmail_thrid")) != NULL) {
+		if (insert_header(m, "message-id", "X-GM-THRID: %s", tptr) != 0)
+			log_warnx("%s: failed to add header X-GM-THRID", a->name);
+	}
+	if ((tptr = find_tag(m->tags, "gmail_labels")) != NULL) {
+		if (insert_header(m, "message-id", "X-GM-LABELS: %s", tptr) != 0)
+			log_warnx("%s: failed to add header X-GM-LABELS", a->name);
 	}
 
 	/* Fill wrapped line list. */

--- a/fetch.h
+++ b/fetch.h
@@ -251,6 +251,7 @@ struct fetch_imap_mail {
 #define IMAP_CAPA_XYZZY 0x2
 #define IMAP_CAPA_STARTTLS 0x4
 #define IMAP_CAPA_NOSPACE 0x8
+#define IMAP_CAPA_GMEXT 0x10
 
 /* fetch-maildir.c */
 extern struct fetch	 fetch_maildir;


### PR DESCRIPTION
This lets us fetch Gmail-specific metadata, such as message id,
thread id, and message labels.  These data are inserted as headers
into incoming messages (X-GM-MSGID, X-GM-THRID, and X-GM-LABELS).

The Gmail IMAP extensions are documented here:
https://developers.google.com/gmail/imap_extensions