### PR TITLE
Disable insecure TLS versions

### DIFF
--- a/connect.c
+++ b/connect.c
@@ -571,10 +571,7 @@ makessl(struct server *srv, int fd, int verify, int timeout, char **cause)
 	int	 n, mode;
 
 	ctx = SSL_CTX_new(SSLv23_client_method());
-	if (srv->tls1)
-		SSL_CTX_set_options(ctx, SSL_OP_ALL);
-	else
-		SSL_CTX_set_options(ctx, SSL_OP_ALL | SSL_OP_NO_TLSv1);
+	SSL_CTX_set_options(ctx, SSL_OP_ALL);
 	SSL_CTX_set_default_verify_paths(ctx);
 	SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
 

--- a/connect.c
+++ b/connect.c
@@ -571,7 +571,13 @@ makessl(struct server *srv, int fd, int verify, int timeout, char **cause)
 	int	 n, mode;
 
 	ctx = SSL_CTX_new(SSLv23_client_method());
-	SSL_CTX_set_options(ctx, SSL_OP_ALL);
+	SSL_CTX_set_options(ctx, SSL_OP_ALL); /* Enable bug workarounds. */
+
+	/* Disable insecure SSL/TLS versions. */
+	SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2); /* DROWN */
+	SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv3); /* POODLE */
+	SSL_CTX_set_options(ctx, SSL_OP_NO_TLSv1); /* BEAST */
+
 	SSL_CTX_set_default_verify_paths(ctx);
 	SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
 

--- a/fdm.conf.5
+++ b/fdm.conf.5
@@ -378,7 +378,6 @@ for details.
 .Op Ic no-apop
 .Op Ic no-uidl
 .Op Ic no-verify
-.Op Ic no-tls1
 .Xc
 These statements define a POP3 or POP3S account.
 The
@@ -440,15 +439,6 @@ keyword makes
 not use the UIDL command to retrieve mails.
 This is mainly useful for broken POP3 servers.
 .Pp
-The
-.Ic no-tls1
-keyword instructs
-.Xr fdm 1
-not to use the TLSv1 protocol with SSL connections.
-Some broken servers will fail in the handshake phase if the
-.Ic tls1
-flag is not unset.
-.Pp
 .Ic starttls
 attempts to use
 .Em STARTTLS
@@ -492,7 +482,6 @@ not be read from
 .Op Ar folders
 .Op Ar only
 .Op Ic no-verify
-.Op Ic no-tls1
 .Op Ic no-cram-md5
 .Op Ic no-login
 .Xc
@@ -599,7 +588,6 @@ basename of the mbox file.
 .Op Ar userpass
 .Ic group Ar group
 .Ic cache Ar cache
-.Op Ic no-tls1
 .Xc
 .It Xo Ic nntps Ic server Ar host
 .Op Ic port Ar port
@@ -609,7 +597,6 @@ basename of the mbox file.
 .Ar group ...
 .Li }
 .Ic cache Ar cache
-.Op Ic no-tls1
 .Xc
 An NNTP account.
 Articles are fetched from the specified group or groups and delivered.

--- a/fdm.h
+++ b/fdm.h
@@ -200,7 +200,6 @@ struct server {
 	char		*port;
 	struct addrinfo	*ai;
 	int		 ssl;
-	int		 tls1;
 	int		 verify;
 };
 

--- a/lex.c
+++ b/lex.c
@@ -152,7 +152,6 @@ static const struct token tokens[] = {
 	{ "no-create", TOKNOCREATE },
 	{ "no-login", TOKNOLOGIN },
 	{ "no-received", TOKNORECEIVED },
-	{ "no-tls1", TOKNOTLS1 },
 	{ "no-uidl", TOKNOUIDL },
 	{ "no-verify", TOKNOVERIFY },
 	{ "none", TOKNONE },

--- a/parse.y
+++ b/parse.y
@@ -203,7 +203,6 @@ yyerror(const char *fmt, ...)
 %token TOKNONE
 %token TOKNORECEIVED
 %token TOKNOT
-%token TOKNOTLS1
 %token TOKNOUIDL
 %token TOKNOVERIFY
 %token TOKOLDONLY
@@ -305,7 +304,7 @@ yyerror(const char *fmt, ...)
 %type  <expritem> expritem
 %type  <exprop> exprop
 %type  <fetch> fetchtype
-%type  <flag> cont not disabled keep execpipe writeappend compress verify tls1
+%type  <flag> cont not disabled keep execpipe writeappend compress verify
 %type  <flag> apop poptype imaptype nntptype nocrammd5 nologin uidl starttls
 %type  <localgid> localgid
 %type  <locks> lock locklist
@@ -1209,12 +1208,11 @@ actitem: execpipe strv
 		 data->path.str = $2;
 		 data->compress = $3;
 	 }
-       | imaptype server userpassnetrc folder1 verify nocrammd5 nologin tls1
-	 starttls
+       | imaptype server userpassnetrc folder1 verify nocrammd5 nologin starttls
 	 {
 		 struct deliver_imap_data	*data;
 
-		 if ($1 && $9)
+		 if ($1 && $8)
 			 yyerror("use either imaps or set starttls");
 
 		 $$ = xcalloc(1, sizeof *$$);
@@ -1239,7 +1237,6 @@ actitem: execpipe strv
 		 data->folder.str = $4;
 		 data->server.ssl = $1;
 		 data->server.verify = $5;
-		 data->server.tls1 = $8;
 		 data->server.host = $2.host;
 		 if ($2.port != NULL)
 			 data->server.port = $2.port;
@@ -1250,7 +1247,7 @@ actitem: execpipe strv
 		 data->server.ai = NULL;
 		 data->nocrammd5 = $6;
 		 data->nologin = $7;
-		 data->starttls = $9;
+		 data->starttls = $8;
 	 }
        | TOKSMTP server from to
 	 {
@@ -2022,15 +2019,6 @@ nologin: TOKNOLOGIN
 		 $$ = 0;
 	 }
 
-tls1: TOKNOTLS1
-	{
-		$$ = 0;
-	}
-      | /* empty */
-	{
-		$$ = 1;
-	}
-
 starttls: TOKSTARTTLS
 	{
 		$$ = 1;
@@ -2192,11 +2180,11 @@ imaponly: only
 		  $$ = FETCH_ONLY_ALL;
 	  }
 
-fetchtype: poptype server userpassnetrc poponly apop verify uidl tls1 starttls
+fetchtype: poptype server userpassnetrc poponly apop verify uidl starttls
 	   {
 		   struct fetch_pop3_data	*data;
 
-		   if ($1 && $9)
+		   if ($1 && $8)
 			   yyerror("use either pop3s or set starttls");
 
 		   $$.fetch = &fetch_pop3;
@@ -2218,7 +2206,6 @@ fetchtype: poptype server userpassnetrc poponly apop verify uidl tls1 starttls
 
 		   data->server.ssl = $1;
 		   data->server.verify = $6;
-		   data->server.tls1 = $8;
 		   data->server.host = $2.host;
 		   if ($2.port != NULL)
 			   data->server.port = $2.port;
@@ -2229,7 +2216,7 @@ fetchtype: poptype server userpassnetrc poponly apop verify uidl tls1 starttls
 		   data->server.ai = NULL;
 		   data->apop = $5;
 		   data->uidl = $7;
-		   data->starttls = $9;
+		   data->starttls = $8;
 
 		   data->path = $4.path;
 		   data->only = $4.only;
@@ -2251,11 +2238,11 @@ fetchtype: poptype server userpassnetrc poponly apop verify uidl tls1 starttls
 		   data->only = $5.only;
 	   }
 	 | imaptype server userpassnetrc folderlist imaponly verify nocrammd5
-	   nologin tls1 starttls
+	   nologin starttls
 	   {
 		   struct fetch_imap_data	*data;
 
-		   if ($1 && $10)
+		   if ($1 && $9)
 			   yyerror("use either imaps or set starttls");
 
 		   $$.fetch = &fetch_imap;
@@ -2278,7 +2265,6 @@ fetchtype: poptype server userpassnetrc poponly apop verify uidl tls1 starttls
 		   data->folders = $4;
 		   data->server.ssl = $1;
 		   data->server.verify = $6;
-		   data->server.tls1 = $9;
 		   data->server.host = $2.host;
 		   if ($2.port != NULL)
 			   data->server.port = $2.port;
@@ -2290,7 +2276,7 @@ fetchtype: poptype server userpassnetrc poponly apop verify uidl tls1 starttls
 		   data->only = $5;
 		   data->nocrammd5 = $7;
 		   data->nologin = $8;
-		   data->starttls = $10;
+		   data->starttls = $9;
 	   }
 	 | TOKIMAP TOKPIPE replstrv userpass folderlist imaponly
 	   {
@@ -2329,7 +2315,7 @@ fetchtype: poptype server userpassnetrc poponly apop verify uidl tls1 starttls
 		   $$.data = data;
 		   data->mboxes = $1;
 	   }
-	 | nntptype server userpassnetrc groups TOKCACHE replpathv verify tls1
+	 | nntptype server userpassnetrc groups TOKCACHE replpathv verify
 	   {
 		   struct fetch_nntp_data	*data;
 		   char				*cause;
@@ -2368,7 +2354,6 @@ fetchtype: poptype server userpassnetrc poponly apop verify uidl tls1 starttls
 
 		   data->server.ssl = $1;
 		   data->server.verify = $7;
-		   data->server.tls1 = $8;
 		   data->server.host = $2.host;
 		   if ($2.port != NULL)
 			   data->server.port = $2.port;


### PR DESCRIPTION
The proposal is to disable SSLv2, SSLv3 and TLSv1.0. They are known to be insecure, even Thunderbird doesn't accept SSL out of the box.

First patch removes no-tls1 option, that is an old (2013) workaround option to disable TLSv1.0. The second patch disables TLSv1.0 completely so no-tls1 option does not make sense anyway.