### PR TITLE
Cipher version

### DIFF
--- a/child-fetch.c
+++ b/child-fetch.c
@@ -33,16 +33,6 @@
 #include "fetch.h"
 #include "match.h"
 
-
-#if OPENSSL_VERSION_NUMBER >= 0x10001000L && \
-    OPENSSL_VERSION_NUMBER < 0x10100004L
-// definitions copied from ssl_locl.h
-# define SSL_VERSION_FIX
-# define SSL_SSLV2               0x00000001UL
-# define SSL_SSLV3               0x00000002UL
-# define SSL_TLSV1_2             0x00000004UL
-#endif
-
 void	fetch_status(struct account *, double);
 int	fetch_account(struct account *, struct io *, int, double);
 int	fetch_match(struct account *, struct msg *, struct msgbuf *);
@@ -548,23 +538,7 @@ account_get_method(struct account *a, char *buf,size_t len)
 	}
 
 	if(cipher != NULL) {
-#ifdef SSL_VERSION_FIX
-		//Work around bug in openssl prior to 1.1.0 release:
-		//SSL_CIPHER_get_version() incorrectly identified
-		//TLSv1.2 as TLSv1/SSLv3
-		alg_ssl = cipher->algorithm_ssl;
-		if (alg_ssl & SSL_SSLV2)
-			cipher_version = "SSLv2";
-		else if (alg_ssl & SSL_SSLV3)
-			cipher_version = "SSLv3";
-		else if (alg_ssl & SSL_TLSV1_2)
-			cipher_version = "TLSv1.2";
-		else
-			cipher_version = "unknown";
-#else
 		cipher_version = SSL_CIPHER_get_version(cipher);
-#endif
-
 		cipher_name = SSL_CIPHER_get_name(cipher);
 		cipher_bits = SSL_CIPHER_get_bits(cipher,NULL);
 		snprintf(tmp,128,"version=%s %s %d bits",cipher_version, cipher_name, cipher_bits);

--- a/mail.c
+++ b/mail.c
@@ -213,9 +213,11 @@ insert_header(struct mail *m, const char *before, const char *fmt, ...)
 		/* Insert before header. */
 		ptr = find_header(m, before, &len, 0);
 		if (ptr == NULL) {
-		       log_debug3("insert_header(): \"%s\" not found, adding header to the top.",before);
+			log_debug3("header \"%s\" not found, adding to the top",
+			    before);
 			off = 0;
-		} else off = ptr - m->data;
+		} else
+			off = ptr - m->data;
 	} else {
 		/* Insert at the end. */
 		if (m->body == 0) {


### PR DESCRIPTION
Enhance the "Received" header to include information about the protocol used to fetch email, as well as the SSL protocol and cipher used (if any) allowing users to verify that messages were retrieved securely.

Two versions of this patch:
[b561f80](https://github.com/nicm/fdm/commit/b561f802391fa353e3e5d2255ee29ed96c211f42) (first commit) Provides basic functionality but does not correctly identify TLSv1.2 when compiled with OpenSSL prior to the 1.1.0 release.
[ba3f04b](https://github.com/nicm/fdm/commit/ba3f04b3ca53b7252663d89a7e5acca988762f24) (second commit) Works around this bug in OpenSSL releases between 1.0.1 and 1.1.0.
