### PR TITLE
Change to debug messages in mail-state.c

### DIFF
--- a/mail-state.c
+++ b/mail-state.c
@@ -171,13 +171,13 @@ next_expritem:
 	if (mctx->expritem != NULL)
 		return (MAIL_CONTINUE);
 
-	log_debug3("%s: finished rule %u, result %d", a->name, mctx->rule->idx,
+	log_debug3("%s: finished rule %u, result %d", a->name, mctx->rule->idx+1,
 	    mctx->result);
 
 	/* If the result was false, skip to find the next rule. */
 	if (!mctx->result)
 		goto next_rule;
-	log_debug2("%s: matched to rule %u", a->name, mctx->rule->idx);
+	log_debug2("%s: matched to rule %u", a->name, mctx->rule->idx+1);
 
 	/*
 	 * If this rule is stop, mark the context so when we get back after
@@ -306,7 +306,7 @@ done:
 	/* Remove completed action from queue. */
 	TAILQ_REMOVE(&mctx->dqueue, dctx, entry);
 	log_debug("%s: message %u delivered (rule %u, %s) in %.3f seconds",
-	    a->name, m->idx, dctx->rule->idx,
+	    a->name, m->idx, dctx->rule->idx+1,
 	    dctx->actitem->deliver->name, get_time() - dctx->tim);
 	user_free(dctx->udata);
 	xfree(dctx);

--- a/parse-fn.c
+++ b/parse-fn.c
@@ -218,15 +218,15 @@ print_rule(struct rule *r)
 		su = xstrdup("");
 	if (r->lambda != NULL) {
 		make_actlist(r->lambda->list, desc, sizeof desc);
-		log_debug2("added rule %u:%s matches=%slambda=%s", r->idx,
+		log_debug2("added rule %u:%s matches=%slambda=%s", r->idx+1,
 		    su, s, desc);
 	} else if (r->actions != NULL) {
 		ss = fmt_replstrs("", r->actions);
-		log_debug2("added rule %u:%s matches=%sactions=%s", r->idx,
+		log_debug2("added rule %u:%s matches=%sactions=%s", r->idx+1,
 		    su, s, ss);
 		xfree(ss);
 	} else
-		log_debug2("added rule %u: matches=%snested", r->idx, s);
+		log_debug2("added rule %u: matches=%snested", r->idx+1, s);
 	xfree(su);
 }
 


### PR DESCRIPTION
It is a bit confusing to debug matching patterns in fdm.conf as the debug messages number your rules from 0 (i.e. the first rule is rule 0, etc). This patch renumbers them from 1 solely for debugging/logging purposes.