### PR TITLE
Daemon mode and IMAP IDLE

### DIFF
--- a/child-fetch.c
+++ b/child-fetch.c
@@ -339,6 +339,7 @@ fetch_account(struct account *a, struct io *pio, int nflags, double tim)
 	struct iolist	 iol;
 	int		 aborted, complete, holding, timeout;
 
+restart:
 	log_debug2("%s: fetching", a->name);
 
 	TAILQ_INIT(&fetch_matchq);
@@ -425,6 +426,11 @@ fetch_account(struct account *a, struct io *pio, int nflags, double tim)
 				/* Fetch again - no blocking. */
 				log_debug3("%s: fetch, again", a->name);
 				continue;
+			case FETCH_RESTART:
+				log_debug("%s: sleeping",a->name);
+				sleep(5); // For debugging. Change to 300
+				log_debug("%s: fetch, again",a->name);
+				continue;
 			case FETCH_BLOCK:
 				/* Fetch again - allow blocking. */
 				log_debug3("%s: fetch, block", a->name);
@@ -495,6 +501,13 @@ finished:
 	TAILQ_FOREACH(cache, &conf.caches, entry) {
 		if (cache->db != NULL)
 			db_close(cache->db);
+	}
+
+	/* In daemon mode, always try to restart. */
+	/* If there were errors here, we could add a re-try limit. */
+	if (conf.daemon) {
+		sleep(5);
+		goto restart;
 	}
 
 	/* Print results. */

--- a/fdm.1
+++ b/fdm.1
@@ -62,9 +62,13 @@ if that doesn't exist.
 .It Fl d
 Run in daemon mode. Use IMAP
 .Pa idle
-command if available, otherwise check all accounts repeatedly with a 
+command if available, otherwise check all accounts repeatedly with a
 delay. In daemon mode, only the first folder in each account will be
-checked.
+checked. Implies
+.Fl l .
+Daemon mode is only compatible with the
+.Ic fetch
+command.
 .It Fl h
 Look at the
 .Ev HOME

--- a/fdm.1
+++ b/fdm.1
@@ -62,7 +62,8 @@ if that doesn't exist.
 .It Fl d
 Run in daemon mode. Use IMAP
 .Pa idle
-command if available, otherwise loop through accounts with a 60 second delay.
+command if available, otherwise check all accounts repeatedly with a 5
+second delay.
 .It Fl h
 Look at the
 .Ev HOME

--- a/fdm.1
+++ b/fdm.1
@@ -23,7 +23,7 @@
 .Sh SYNOPSIS
 .Nm fdm
 .Bk -words
-.Op Fl hklmnqv
+.Op Fl dhklmnqv
 .Op Fl a Ar account
 .Op Fl D Ar name Ns = Ns Ar value
 .Op Fl f Ar conffile
@@ -59,6 +59,10 @@ Default is
 or
 .Pa /etc/fdm.conf
 if that doesn't exist.
+.It Fl d
+Run in daemon mode. Use IMAP
+.Pa idle
+command if available, otherwise loop through accounts with a 60 second delay.
 .It Fl h
 Look at the
 .Ev HOME

--- a/fdm.1
+++ b/fdm.1
@@ -62,8 +62,9 @@ if that doesn't exist.
 .It Fl d
 Run in daemon mode. Use IMAP
 .Pa idle
-command if available, otherwise check all accounts repeatedly with a 5
-second delay.
+command if available, otherwise check all accounts repeatedly with a 
+delay. In daemon mode, only the first folder in each account will be
+checked.
 .It Fl h
 Look at the
 .Ev HOME

--- a/fdm.c
+++ b/fdm.c
@@ -419,7 +419,7 @@ main(int argc, char **argv)
 		if (op != FDMOP_FETCH)
 			fatal("Fetch command must be given for daemon mode.");
 
-		if (daemon(1,0))
+		if (daemon(0,0))
 			fatal("Daemon mode failed.");
 	}
 

--- a/fdm.c
+++ b/fdm.c
@@ -357,6 +357,7 @@ main(int argc, char **argv)
 			break;
 		case 'd':
 			conf.daemon = 1;
+			conf.syslog = 1;
 			break;
 		case 'h':
 			home = getenv("HOME");
@@ -411,6 +412,15 @@ main(int argc, char **argv)
 			op = FDMOP_CACHE;
 		else
 			usage();
+	}
+
+	/* fork off into daemon mode if requested. */
+	if (conf.daemon) {
+		if (op != FDMOP_FETCH)
+			fatal("Fetch command must be given for daemon mode.");
+
+		if (daemon(1,0))
+			fatal("Daemon mode failed.");
 	}
 
 	/* Set debug level and start logging to syslog if necessary. */

--- a/fdm.c
+++ b/fdm.c
@@ -266,7 +266,7 @@ __dead void
 usage(void)
 {
 	fprintf(stderr,
-	    "usage: %s [-hklmnqv] [-a name] [-D name=value] [-f conffile] "
+	    "usage: %s [-dhklmnqv] [-a name] [-D name=value] [-f conffile] "
 	    "[-u user] [-x name] [fetch|poll|cache] [arguments]\n", __progname);
 	exit(1);
 }
@@ -326,6 +326,12 @@ main(int argc, char **argv)
 	conf.def_user = NULL;
 	conf.cmd_user = NULL;
 	conf.max_accts = -1;
+	conf.keep_all = 0;
+	conf.daemon = 0;
+	conf.syslog = 0;
+	conf.allow_many = 0;
+	conf.check_only = 0;
+	conf.debug = 0;
 	conf.strip_chars = xstrdup(DEFSTRIPCHARS);
 
 	conf.user_order = xmalloc(sizeof *conf.user_order);
@@ -336,7 +342,7 @@ main(int argc, char **argv)
 	ARRAY_INIT(&conf.excl);
 
 	ARRAY_INIT(&macros);
-	while ((opt = getopt(argc, argv, "a:D:f:hklmnqu:vx:")) != -1) {
+	while ((opt = getopt(argc, argv, "a:D:f:dhklmnqu:vx:")) != -1) {
 		switch (opt) {
 		case 'a':
 			ARRAY_ADD(&conf.incl, xstrdup(optarg));
@@ -347,6 +353,9 @@ main(int argc, char **argv)
 		case 'f':
 			if (conf.conf_file == NULL)
 				conf.conf_file = xstrdup(optarg);
+			break;
+		case 'd':
+			conf.daemon = 1;
 			break;
 		case 'h':
 			home = getenv("HOME");

--- a/fdm.c
+++ b/fdm.c
@@ -316,6 +316,7 @@ main(int argc, char **argv)
 	conf.lock_timeout = DEFLOCKTIMEOUT;
 	conf.max_size = DEFMAILSIZE;
 	conf.timeout = DEFTIMEOUT;
+	conf.idle_timeout = DEFIDLETIMEOUT;
 	conf.lock_types = LOCK_FLOCK;
 	conf.impl_act = DECISION_NONE;
 	conf.purge_after = 0;

--- a/fdm.h
+++ b/fdm.h
@@ -613,6 +613,7 @@ struct conf {
 
 	char			*conf_file;
 	char			*strip_chars;
+	int			 daemon;
 	int			 check_only;
 	int			 allow_many;
 	int			 keep_all;

--- a/fdm.h
+++ b/fdm.h
@@ -63,6 +63,7 @@
 #define DEFSTRIPCHARS	"\\<>$%^&*|{}[]\"'`;"
 #define MAXACTIONCHAIN	5
 #define DEFTIMEOUT	(900 * 1000)
+#define DEFIDLETIMEOUT	(28 * 60 * 60)			/* 28 minutes */
 #define LOCKSLEEPTIME	10000				/* 0.1 seconds */
 #define MAXNAMESIZE	64
 #define DEFUMASK	(S_IRWXG|S_IRWXO)
@@ -636,6 +637,7 @@ struct conf {
 
 	size_t			 max_size;
 	int			 timeout;
+	int			 idle_timeout;
 	int			 del_big;
 	int			 ignore_errors;
 	u_int			 lock_types;

--- a/fetch.h
+++ b/fetch.h
@@ -26,6 +26,7 @@
 #define FETCH_MAIL 4
 #define FETCH_EXIT 5
 #define FETCH_RESTART 6
+#define FETCH_TICK 7
 
 /* Fetch flags. */
 #define FETCH_PURGE 0x1
@@ -212,6 +213,7 @@ struct fetch_imap_data {
 
 	int		 capa;
 	int		 tag;
+	time_t		 idle_restart_time;
 
 	ARRAY_DECL(, u_int) wanted;
 	ARRAY_DECL(, u_int) dropped;
@@ -293,6 +295,7 @@ int	imap_invalid(struct account *, const char *);
 int	imap_state_init(struct account *, struct fetch_ctx *);
 int	imap_state_connected(struct account *, struct fetch_ctx *);
 int	imap_state_select1(struct account *, struct fetch_ctx *);
+int	imap_state_idle1(struct account *, struct fetch_ctx *);
 int	imap_commit(struct account *, struct mail *);
 void	imap_abort(struct account *);
 u_int	imap_total(struct account *);

--- a/fetch.h
+++ b/fetch.h
@@ -252,6 +252,7 @@ struct fetch_imap_mail {
 #define IMAP_CAPA_STARTTLS 0x4
 #define IMAP_CAPA_NOSPACE 0x8
 #define IMAP_CAPA_GMEXT 0x10
+#define IMAP_CAPA_IDLE 0x20
 
 /* fetch-maildir.c */
 extern struct fetch	 fetch_maildir;

--- a/fetch.h
+++ b/fetch.h
@@ -25,6 +25,7 @@
 #define FETCH_ERROR 3
 #define FETCH_MAIL 4
 #define FETCH_EXIT 5
+#define FETCH_RESTART 6
 
 /* Fetch flags. */
 #define FETCH_PURGE 0x1

--- a/imap-common.c
+++ b/imap-common.c
@@ -1120,9 +1120,16 @@ imap_state_close(struct account *a, struct fetch_ctx *fctx)
 		return (FETCH_AGAIN);
 	}
 
+	if (conf.daemon) {
+		data->folder = 0; // go back to the first folder.
+		fctx->state = imap_state_select1;
+		return (FETCH_RESTART);
+	}
+
 	if (imap_putln(a, "%u LOGOUT", ++data->tag) != 0)
 		return (FETCH_ERROR);
 	fctx->state = imap_state_quit;
+
 	return (FETCH_BLOCK);
 }
 

--- a/imap-common.c
+++ b/imap-common.c
@@ -412,6 +412,9 @@ imap_state_capability1(struct account *a, struct fetch_ctx *fctx)
 	if (strstr(line, "STARTTLS") != NULL)
 		data->capa |= IMAP_CAPA_STARTTLS;
 
+	if (strstr(line, "IDLE") != NULL)
+		data->capa |= IMAP_CAPA_IDLE;
+
 	fctx->state = imap_state_capability2;
 	return (FETCH_AGAIN);
 }

--- a/imap-common.c
+++ b/imap-common.c
@@ -1210,7 +1210,7 @@ imap_state_idle4(struct account *a, struct fetch_ctx *fctx)
 	if (!imap_okay(line))
 		return (imap_bad(a, line));
 
-	log_debug("%s: idle4: got OK",a->name);
+	log_debug3("%s: idle4: got OK",a->name);
 
         fctx->state = imap_state_search1;
         return (FETCH_AGAIN);

--- a/imap-common.c
+++ b/imap-common.c
@@ -1239,6 +1239,8 @@ imap_state_close(struct account *a, struct fetch_ctx *fctx)
 		/* no daemon mode -- fetch more folders then log out. */
 		data->folder++;
 		if (data->folder != ARRAY_LENGTH(data->folders)) {
+			ARRAY_FREE(&data->wanted);
+			data->committed = 0;
 			fctx->state = imap_state_select1;
 			return (FETCH_AGAIN);
 		}

--- a/lex.c
+++ b/lex.c
@@ -111,6 +111,7 @@ static const struct token tokens[] = {
 	{ "headers", TOKHEADERS },
 	{ "hour", TOKHOURS },
 	{ "hours", TOKHOURS },
+	{ "idle-timeout", TOKIDLETIMEOUT },
 	{ "ignore-errors", TOKIGNOREERRORS },
 	{ "imap", TOKIMAP },
 	{ "imaps", TOKIMAPS },

--- a/parse.y
+++ b/parse.y
@@ -167,6 +167,7 @@ yyerror(const char *fmt, ...)
 %token TOKHEADER
 %token TOKHEADERS
 %token TOKHOURS
+%token TOKIDLETIMEOUT
 %token TOKIGNOREERRORS
 %token TOKIMAP
 %token TOKIMAPS
@@ -603,6 +604,10 @@ set: TOKSET TOKMAXSIZE size
    | TOKSET TOKDELTOOBIG
      {
 	     conf.del_big = 1;
+     }
+   | TOKSET TOKIDLETIMEOUT time
+     {
+	     conf.idle_timeout = $3;
      }
    | TOKSET TOKIGNOREERRORS
      {


### PR DESCRIPTION
Daemon mode causes fetch children to restart after a short delay. For IMAP servers that do not support IDLE, the fetch process tries to remain logged in while the child process sleep()s for a couple of minutes.

Also includes a preliminary implementation of IMAP IDLE.

Requires further tuning, testing and error handling, but it seems to work with gmail, Yahoo mail and various other IMAP servers.