### PR TITLE
Daemon mode

### DIFF
--- a/child-fetch.c
+++ b/child-fetch.c
@@ -135,7 +135,7 @@ fetch_poll(struct account *a, struct iolist *iol, struct io *pio, int timeout)
 	struct io	*rio;
 	char		*cause;
 	double		 tim;
-	int		 dur;
+	int		 remaining;
 
 	tim = get_time();
 
@@ -158,11 +158,15 @@ restart:
 		xfree(cause);
 		return (-1);
 	}
-	dur = (int)floor(get_time() - tim);
-	if (a->wakein && (a->wakein > dur)) { /* poll returned early, sleep. */
-		sleep(a->wakein - dur);
-		timeout = a->wakein = 0;
-		goto restart;
+	remaining = a->wakein - ((int)floor(get_time() - tim));
+	if (a->wakein) {
+		a->wakein = 0;
+		if (remaining > 0) {
+			/* poll returned early, sleep. */
+			sleep(remaining);
+			timeout = 0;
+			goto restart;
+		}
 	}
 
 	return (0);

--- a/child-fetch.c
+++ b/child-fetch.c
@@ -160,13 +160,12 @@ restart:
 	}
 	remaining = a->wakein - ((int)floor(get_time() - tim));
 	if (a->wakein) {
-		a->wakein = 0;
 		if (remaining > 0) {
 			/* poll returned early, sleep. */
-			sleep(remaining);
-			timeout = 0;
+			timeout = sleep(remaining);
 			goto restart;
 		}
+		a->wakein = 0;
 	}
 
 	return (0);
@@ -439,13 +438,14 @@ restart:
 				/* Fetch again - no blocking. */
 				log_debug3("%s: fetch, again", a->name);
 				continue;
-			case FETCH_WAIT:
-				log_debug("%s: fetch, restart (%u secs)",
-				    a->name,a->wakein);
-				break;
 			case FETCH_BLOCK:
 				/* Fetch again - allow blocking. */
-				log_debug3("%s: fetch, block", a->name);
+				if (a->wakein)
+					log_debug(
+					  "%s: fetch, block (wake in %u secs)",
+					  a->name,a->wakein);
+				else
+					log_debug3("%s: fetch, block", a->name);
 				break;
 			case FETCH_MAIL:
 				/* Mail ready. */

--- a/child-fetch.c
+++ b/child-fetch.c
@@ -339,6 +339,7 @@ fetch_account(struct account *a, struct io *pio, int nflags, double tim)
 	struct iolist	 iol;
 	int		 aborted, complete, holding, timeout;
 
+restart:
 	log_debug2("%s: fetching", a->name);
 
 	TAILQ_INIT(&fetch_matchq);
@@ -425,6 +426,11 @@ fetch_account(struct account *a, struct io *pio, int nflags, double tim)
 				/* Fetch again - no blocking. */
 				log_debug3("%s: fetch, again", a->name);
 				continue;
+			case FETCH_RESTART:
+				log_debug("%s: sleeping",a->name);
+				sleep(5); // For debugging. Change to 300
+				log_debug("%s: fetch, again",a->name);
+				continue;
 			case FETCH_BLOCK:
 				/* Fetch again - allow blocking. */
 				log_debug3("%s: fetch, block", a->name);
@@ -495,6 +501,13 @@ finished:
 	TAILQ_FOREACH(cache, &conf.caches, entry) {
 		if (cache->db != NULL)
 			db_close(cache->db);
+	}
+
+	/* In daemon mode, always try to restart. */
+	/* If there were errors here, we could add a re-try limit. */
+	if (conf.daemon) {
+		sleep(5);
+		goto restart;
 	}
 
 	/* Print results. */

--- a/child-fetch.c
+++ b/child-fetch.c
@@ -428,8 +428,8 @@ restart:
 				continue;
 			case FETCH_RESTART:
 				log_debug("%s: sleeping",a->name);
-				sleep(5); // For debugging. Change to 300
-				log_debug("%s: fetch, again",a->name);
+				sleep(conf.fetch_freq);
+				log_debug("%s: fetch, restart",a->name);
 				continue;
 			case FETCH_BLOCK:
 				/* Fetch again - allow blocking. */
@@ -503,19 +503,18 @@ finished:
 			db_close(cache->db);
 	}
 
-	/* In daemon mode, always try to restart. */
-	/* If there were errors here, we could add a re-try limit. */
-	if (conf.daemon) {
-		sleep(5);
-		goto restart;
-	}
-
 	/* Print results. */
 	if (nflags & FETCH_POLL)
 		log_info("%s: %u messages found", a->name, a->fetch->total(a));
 	else
 		fetch_status(a, tim);
-	return (aborted);
+
+	/* In daemon mode, always try to restart. */
+	if (conf.daemon) {
+		sleep(conf.fetch_freq);
+		goto restart;
+	} else
+		return (aborted);
 }
 
 /*

--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,7 @@ AC_CHECK_HEADERS(
 	[ \
 		sys/queue.h \
 		sys/tree.h \
+		math.h \
 	]
 )
 AC_CHECK_FUNCS(
@@ -62,6 +63,10 @@ AC_CHECK_FUNCS(
 		setresgid \
 	]
 )
+
+AC_SEARCH_LIBS(
+	floor,
+	[m])
 
 AC_SEARCH_LIBS(
 	tdb_open,

--- a/fdm.1
+++ b/fdm.1
@@ -60,7 +60,7 @@ or
 .Pa /etc/fdm.conf
 if that doesn't exist.
 .It Fl d
-Run in daemon mode. Loop through accounts with a second delay.
+Run in daemon mode. Loop through accounts with a delay.
 .It Fl h
 Look at the
 .Ev HOME

--- a/fdm.1
+++ b/fdm.1
@@ -23,7 +23,7 @@
 .Sh SYNOPSIS
 .Nm fdm
 .Bk -words
-.Op Fl hklmnqv
+.Op Fl dhklmnqv
 .Op Fl a Ar account
 .Op Fl D Ar name Ns = Ns Ar value
 .Op Fl f Ar conffile
@@ -59,6 +59,8 @@ Default is
 or
 .Pa /etc/fdm.conf
 if that doesn't exist.
+.It Fl d
+Run in daemon mode. Loop through accounts with a second delay.
 .It Fl h
 Look at the
 .Ev HOME

--- a/fdm.1
+++ b/fdm.1
@@ -61,6 +61,11 @@ or
 if that doesn't exist.
 .It Fl d
 Run in daemon mode. Loop through accounts with a delay.
+Implies
+.Fl l .
+Daemon mode is only compatible with the
+.Ic fetch
+command.
 .It Fl h
 Look at the
 .Ev HOME

--- a/fdm.c
+++ b/fdm.c
@@ -332,6 +332,7 @@ main(int argc, char **argv)
 	conf.allow_many = 0;
 	conf.check_only = 0;
 	conf.debug = 0;
+	conf.fetch_freq = DEFFETCHFREQ;
 	conf.strip_chars = xstrdup(DEFSTRIPCHARS);
 
 	conf.user_order = xmalloc(sizeof *conf.user_order);

--- a/fdm.c
+++ b/fdm.c
@@ -418,7 +418,7 @@ main(int argc, char **argv)
 		if (op != FDMOP_FETCH)
 			fatal("Fetch command must be given for daemon mode.");
 
-		if (daemon(1,0))
+		if (daemon(0,0))
 			fatal("Daemon mode failed.");
 	}
 

--- a/fdm.c
+++ b/fdm.c
@@ -266,7 +266,7 @@ __dead void
 usage(void)
 {
 	fprintf(stderr,
-	    "usage: %s [-hklmnqv] [-a name] [-D name=value] [-f conffile] "
+	    "usage: %s [-dhklmnqv] [-a name] [-D name=value] [-f conffile] "
 	    "[-u user] [-x name] [fetch|poll|cache] [arguments]\n", __progname);
 	exit(1);
 }
@@ -326,6 +326,12 @@ main(int argc, char **argv)
 	conf.def_user = NULL;
 	conf.cmd_user = NULL;
 	conf.max_accts = -1;
+	conf.keep_all = 0;
+	conf.daemon = 0;
+	conf.syslog = 0;
+	conf.allow_many = 0;
+	conf.check_only = 0;
+	conf.debug = 0;
 	conf.strip_chars = xstrdup(DEFSTRIPCHARS);
 
 	conf.user_order = xmalloc(sizeof *conf.user_order);
@@ -336,7 +342,7 @@ main(int argc, char **argv)
 	ARRAY_INIT(&conf.excl);
 
 	ARRAY_INIT(&macros);
-	while ((opt = getopt(argc, argv, "a:D:f:hklmnqu:vx:")) != -1) {
+	while ((opt = getopt(argc, argv, "a:D:f:dhklmnqu:vx:")) != -1) {
 		switch (opt) {
 		case 'a':
 			ARRAY_ADD(&conf.incl, xstrdup(optarg));
@@ -347,6 +353,9 @@ main(int argc, char **argv)
 		case 'f':
 			if (conf.conf_file == NULL)
 				conf.conf_file = xstrdup(optarg);
+			break;
+		case 'd':
+			conf.daemon = 1;
 			break;
 		case 'h':
 			home = getenv("HOME");

--- a/fdm.c
+++ b/fdm.c
@@ -356,6 +356,7 @@ main(int argc, char **argv)
 			break;
 		case 'd':
 			conf.daemon = 1;
+			conf.syslog = 1;
 			break;
 		case 'h':
 			home = getenv("HOME");
@@ -410,6 +411,15 @@ main(int argc, char **argv)
 			op = FDMOP_CACHE;
 		else
 			usage();
+	}
+
+	/* fork off into daemon mode if requested. */
+	if (conf.daemon) {
+		if (op != FDMOP_FETCH)
+			fatal("Fetch command must be given for daemon mode.");
+
+		if (daemon(1,0))
+			fatal("Daemon mode failed.");
 	}
 
 	/* Set debug level and start logging to syslog if necessary. */

--- a/fdm.h
+++ b/fdm.h
@@ -56,6 +56,7 @@
 #define CONFFILE	".fdm.conf"
 #define LOCKFILE	".fdm.lock"
 #define DEFLOCKTIMEOUT	10
+#define DEFFETCHFREQ	60 * 5				/* 5 minutes */
 #define MAXQUEUEVALUE	50
 #define DEFMAILQUEUE	2
 #define DEFMAILSIZE	(32 * 1024 * 1024)		/* 32 MB */
@@ -636,6 +637,7 @@ struct conf {
 
 	size_t			 max_size;
 	int			 timeout;
+	int			 fetch_freq;
 	int			 del_big;
 	int			 ignore_errors;
 	u_int			 lock_types;

--- a/fdm.h
+++ b/fdm.h
@@ -490,6 +490,7 @@ struct account {
 
 	int			 disabled;
 	int			 keep;
+	int		 	 wakein;	/* secs */
 	int		 	 timeout;
 
 	struct fetch		*fetch;

--- a/fdm.h
+++ b/fdm.h
@@ -490,6 +490,7 @@ struct account {
 
 	int			 disabled;
 	int			 keep;
+	int		 	 timeout;
 
 	struct fetch		*fetch;
 	void			*data;

--- a/fdm.h
+++ b/fdm.h
@@ -613,6 +613,7 @@ struct conf {
 
 	char			*conf_file;
 	char			*strip_chars;
+	int			 daemon;
 	int			 check_only;
 	int			 allow_many;
 	int			 keep_all;

--- a/fetch-imap.c
+++ b/fetch-imap.c
@@ -123,12 +123,19 @@ void
 fetch_imap_desc(struct account *a, char *buf, size_t len)
 {
 	struct fetch_imap_data	*data = a->data;
-	char			*folders;
+	char			*folders, timeout[18];
 
 	folders = fmt_strings("folders ", data->folders);
+
+	if (a->timeout != 0)
+		snprintf(timeout,sizeof timeout," timeout %u", a->timeout);
+	else
+		timeout[0] = 0;
+
 	xsnprintf(buf, len,
-	    "imap%s server \"%s\" port %s user \"%s\" %s",
+	    "imap%s server \"%s\" port %s user \"%s\" %s%s%s",
 	    data->server.ssl ? "s" : "", data->server.host, data->server.port,
-	    data->user, folders);
+	    data->user, folders,
+	    data->server.insecure ? " insecure" : "", timeout);
 	xfree(folders);
 }

--- a/fetch-pop3.c
+++ b/fetch-pop3.c
@@ -127,8 +127,15 @@ void
 fetch_pop3_desc(struct account *a, char *buf, size_t len)
 {
 	struct fetch_pop3_data	*data = a->data;
+	char timeout[18];
 
-	xsnprintf(buf, len, "pop3%s server \"%s\" port %s user \"%s\"",
+	if (a->timeout != 0)
+		snprintf(timeout,sizeof timeout," timeout %u", a->timeout);
+	else
+		timeout[0] = 0;
+
+	xsnprintf(buf, len, "pop3%s server \"%s\" port %s user \"%s\"%s%s",
 	    data->server.ssl ? "s" : "", data->server.host, data->server.port,
-	    data->user);
+	    data->user,
+	    data->server.insecure ? " insecure" : "", timeout);
 }

--- a/fetch.h
+++ b/fetch.h
@@ -25,7 +25,7 @@
 #define FETCH_ERROR 3
 #define FETCH_MAIL 4
 #define FETCH_EXIT 5
-#define FETCH_RESTART 6
+#define FETCH_WAIT 6
 
 /* Fetch flags. */
 #define FETCH_PURGE 0x1

--- a/fetch.h
+++ b/fetch.h
@@ -25,7 +25,6 @@
 #define FETCH_ERROR 3
 #define FETCH_MAIL 4
 #define FETCH_EXIT 5
-#define FETCH_WAIT 6
 
 /* Fetch flags. */
 #define FETCH_PURGE 0x1

--- a/fetch.h
+++ b/fetch.h
@@ -25,6 +25,7 @@
 #define FETCH_ERROR 3
 #define FETCH_MAIL 4
 #define FETCH_EXIT 5
+#define FETCH_RESTART 6
 
 /* Fetch flags. */
 #define FETCH_PURGE 0x1

--- a/imap-common.c
+++ b/imap-common.c
@@ -1120,9 +1120,16 @@ imap_state_close(struct account *a, struct fetch_ctx *fctx)
 		return (FETCH_AGAIN);
 	}
 
+	if (conf.daemon) {
+		data->folder = 0; // go back to the first folder.
+		fctx->state = imap_state_select1;
+		return (FETCH_RESTART);
+	}
+
 	if (imap_putln(a, "%u LOGOUT", ++data->tag) != 0)
 		return (FETCH_ERROR);
 	fctx->state = imap_state_quit;
+
 	return (FETCH_BLOCK);
 }
 

--- a/imap-common.c
+++ b/imap-common.c
@@ -1124,7 +1124,7 @@ imap_state_close(struct account *a, struct fetch_ctx *fctx)
 		data->folder = 0; // go back to the first folder.
 		fctx->state = imap_state_select1;
 		a->wakein = conf.fetch_freq;
-		return (FETCH_WAIT);
+		return (FETCH_BLOCK);
 	}
 
 	if (imap_putln(a, "%u LOGOUT", ++data->tag) != 0)

--- a/imap-common.c
+++ b/imap-common.c
@@ -1123,7 +1123,8 @@ imap_state_close(struct account *a, struct fetch_ctx *fctx)
 	if (conf.daemon) {
 		data->folder = 0; // go back to the first folder.
 		fctx->state = imap_state_select1;
-		return (FETCH_RESTART);
+		a->wakein = conf.fetch_freq;
+		return (FETCH_WAIT);
 	}
 
 	if (imap_putln(a, "%u LOGOUT", ++data->tag) != 0)

--- a/io.c
+++ b/io.c
@@ -158,7 +158,7 @@ io_polln(struct io **iop, u_int n, struct io **rio, int timeout, char **cause)
 		xfree(pfds);
 
 		if (error == 0) {
-			if (timeout == 0) {
+			if (timeout != conf.timeout) {
 				errno = EAGAIN;
 				return (-1);
 			}

--- a/lex.c
+++ b/lex.c
@@ -95,6 +95,7 @@ static const struct token tokens[] = {
 	{ "exec", TOKEXEC },
 	{ "expire", TOKEXPIRE },
 	{ "fcntl", TOKFCNTL },
+	{ "fetch-frequency", TOKFETCHFREQ },
 	{ "file-group", TOKFILEGROUP },
 	{ "file-umask", TOKFILEUMASK },
 	{ "flock", TOKFLOCK },

--- a/parse.y
+++ b/parse.y
@@ -311,7 +311,7 @@ yyerror(const char *fmt, ...)
 %type  <flag> insecure
 %type  <localgid> localgid
 %type  <locks> lock locklist
-%type  <number> size time numv retrc expire
+%type  <number> size time numv retrc expire timeout
 %type  <only> only imaponly
 %type  <poponly> poponly
 %type  <replstrs> replstrslist actions rmheaders accounts users
@@ -1063,6 +1063,15 @@ port: TOKPORT replstrv
 		      yyerror("invalid port");
 
 	      xasprintf(&$$, "%lld", $2);
+      }
+
+timeout: /* not present */
+      {
+		$$ = 0;	/* use global value */
+      }
+    | TOKTIMEOUT time
+      {
+		$$ = $2;
       }
 
 server: TOKSERVER replstrv port
@@ -2387,7 +2396,7 @@ fetchtype: poptype server userpassnetrc poponly apop verify uidl starttls
 		   data->server.ai = NULL;
 	   }
 
-account: TOKACCOUNT replstrv disabled users fetchtype keep
+account: TOKACCOUNT replstrv disabled users fetchtype keep timeout
 	 {
 		 struct account		*a;
 		 char			*su, desc[DESCBUFSIZE];
@@ -2402,6 +2411,7 @@ account: TOKACCOUNT replstrv disabled users fetchtype keep
 		 a = xcalloc(1, sizeof *a);
 		 strlcpy(a->name, $2, sizeof a->name);
 		 a->keep = $6;
+		 a->timeout = $7;
 		 a->disabled = $3;
 		 a->users = $4;
 		 a->fetch = $5.fetch;

--- a/parse.y
+++ b/parse.y
@@ -155,6 +155,7 @@ yyerror(const char *fmt, ...)
 %token TOKEXEC
 %token TOKEXPIRE
 %token TOKFCNTL
+%token TOKFETCHFREQ
 %token TOKFILEGROUP
 %token TOKFILEUMASK
 %token TOKFLOCK
@@ -603,6 +604,10 @@ set: TOKSET TOKMAXSIZE size
    | TOKSET TOKDELTOOBIG
      {
 	     conf.del_big = 1;
+     }
+   | TOKSET TOKFETCHFREQ time
+     {
+	     conf.fetch_freq = $3;
      }
    | TOKSET TOKIGNOREERRORS
      {


### PR DESCRIPTION
Implement daemon mode (-d) with "fetch-frequency" configuration option (default 5 minutes). Fork into the background with daemon() and log to syslog, looping through accounts fetching all folders. On errors, try to restart.

To do:
--complete signal handling
--replace sleep() calls with I/O polling
