### PR TITLE
Detect OpenSSL using either SSL_library_init or OPENSSL_init_ssl function

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,11 +92,16 @@ AC_SEARCH_LIBS(
 if test "x$found_libcrypto" = xno; then
 	AC_MSG_ERROR("libcrypto not found")
 fi
+found_libssl=no
+AC_SEARCH_LIBS(
+  OPENSSL_init_ssl,
+  [ssl],
+  found_libssl=yes
+)
 AC_SEARCH_LIBS(
 	SSL_library_init,
 	[ssl],
-	found_libssl=yes,
-	found_libssl=no
+	found_libssl=yes
 )
 if test "x$found_libssl" = xno; then
 	AC_MSG_ERROR("libssl not found")


### PR DESCRIPTION
Since OpenSSL 1.1.0 the SSL_library_init is just a backward
compatibility macro defined to OPENSSL_init_ssl. Thus it will not be
properly detected with AC_SEARCH_LIBS(SSL_library_init, ...) alone.