### PR TITLE
Use Server Name Indication extension.

### DIFF
--- a/connect.c
+++ b/connect.c
@@ -589,6 +589,11 @@ makessl(struct server *srv, int fd, int verify, int timeout, char **cause)
 		goto error;
 	}
 
+	if (SSL_set_tlsext_host_name(ssl, srv->host) != 1) {
+		*cause = sslerror("SSL_set_tlsext_host_name");
+		goto error;
+	}
+
 	if (SSL_set_fd(ssl, fd) != 1) {
 		*cause = sslerror("SSL_set_fd");
 		goto error;


### PR DESCRIPTION
Google requires TLS 1.3 clients to use SNI extensions or otherwise
responds with self-signed certificate with subject "No SNI provided;
please fix your client". Use SNI extension to avoid the issue.