### PR TITLE
Mark files created by parser generator as BUILT_SOURCES

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,7 @@
 
 bin_PROGRAMS = fdm
 CLEANFILES = parse.c parse.h
+BUILT_SOURCES = parse.c parse.h
 
 EXTRA_DIST = \
 	CHANGES README MANUAL \


### PR DESCRIPTION
This ensures that they are generated early in build process to
avoid lex.c including parse.h before it had a chance of being built
(in the case of parallel builds).