### PR TITLE
Fix compilation without b64_ntop

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -123,6 +123,3 @@ endif
 if NO_STRTONUM
 nodist_fdm_SOURCES += compat/strtonum.c
 endif
-if NO_B64_NTOP
-nodist_fdm_SOURCES += compat/base64.c
-endif


### PR DESCRIPTION
This should not be included twice as there are no if guards.