### PR TITLE
Adjust mremap(2) call for NetBSD

### DIFF
--- a/shm-mmap.c
+++ b/shm-mmap.c
@@ -218,7 +218,11 @@ shm_resize(struct shm *shm, size_t nmemb, size_t size)
 		return (NULL);
 
 #ifdef HAVE_MREMAP
+#if defined(__NetBSD__)
+	shm->data = mremap(shm->data, shm->size, NULL, newsize, 0);
+#else
 	shm->data = mremap(shm->data, shm->size, newsize, MREMAP_MAYMOVE);
+#endif
 #else
 	shm->data = mmap(NULL, newsize, SHM_PROT, SHM_FLAGS, shm->fd, 0);
 #endif


### PR DESCRIPTION
mremap is recognized in the configure phase on NetBSD but it fails
to build due incompatibilities.

On NetBSD MREMAP_MAYMOVE flag is the default behaviour (and such
flag don't exist) and mremap(2) has an extra argument compared to
the glibc one.