### PR TITLE
Allow empty from for delivery status notifications (RFC 1123 section …

### DIFF
--- a/deliver-smtp.c
+++ b/deliver-smtp.c
@@ -105,7 +105,7 @@ deliver_smtp_deliver(struct deliver_ctx *dctx, struct actitem *ti)
 		from = xstrdup(ptr);
 	else {
 		from = replacestr(&data->from, m->tags, m, &m->rml);
-		if (from == NULL || *from == '\0') {
+		if (from == NULL) {
 			xasprintf(&cause, "%s: empty from", a->name);
 			goto error;
 		}


### PR DESCRIPTION
…5.2.9)

Hey there,

I just started using fdm to fetch mails from my shared hoster's mailbox and deliver them to my MTA for forwarding to my local mailman3 installation. As mailman3 needs to also process bounce mails, which have an empty envelope from address, fdm needs to support empty from addresses (which conforms to RFC 1123).

For context, this is (part of) my fdm.conf:

```
match case "^Return-Path: <(.*)>" in headers action tag "Return-Path" value "%1" continue
match case "^X-Original-To: (.*)" in headers action tag "X-Original-To" value "%1" continue
match all action smtp server "localhost" from "%[Return-Path]" to "%[X-Original-To]"

```
With the patch fdm delivers bounce mails successfully.

Cheers,
Volker