### PR TITLE
Allow saving messages to Apple iCloud via IMAP

### DIFF
--- a/deliver-imap.c
+++ b/deliver-imap.c
@@ -234,7 +234,7 @@ retry:
 	 * every CRLF was a CR if the server has XYZZY.
 	 */
 	count_lines(m, &total, &body);
-	maillen = m->size + total - 1;
+	maillen = m->size + total - 2;
 	if (fdata.capa & IMAP_CAPA_XYZZY) {
 		log_debug2("%s: adjusting size: actual %zu", a->name, maillen);
 		maillen = m->size;

--- a/deliver-imap.c
+++ b/deliver-imap.c
@@ -211,9 +211,29 @@ deliver_imap_deliver(struct deliver_ctx *dctx, struct actitem *ti)
 		goto error;
 
 retry:
+	/*
+	 * Determine the mail size, not forgetting lines are CRLF
+	 * terminated. The Google IMAP server is written strangely, so send
+	 * the size as if every CRLF was a CR if the server has XYZZY.
+	 */
+	count_lines(m, &total, &body);
+	maillen = m->size + total - 2;
+	if (fdata.capa & IMAP_CAPA_XYZZY) {
+		log_debug2("%s: adjusting size: actual %zu", a->name, maillen);
+		maillen = m->size;
+	}
+
 	/* Send an append command. */
-	if (imap_putln(a, "%u APPEND {%zu}", ++fdata.tag, strlen(folder)) != 0)
-		goto error;
+	if (imap_not_clean(folder)) {
+		if (imap_putln(a, "%u APPEND {%zu}", ++fdata.tag, strlen(folder)) != 0)
+			goto error;
+	} else {
+		if (imap_putln(a, "%u APPEND \"%s\" {%zu}", ++fdata.tag, folder, maillen) != 0)
+			goto error;
+
+		goto data;
+	}
+
 	switch (deliver_imap_waitappend(a, &fctx, io, &line)) {
 	case IMAP_TAG_ERROR:
 		if (line != NULL)
@@ -228,17 +248,6 @@ retry:
 		goto error;
 	}
 
-	/*
-	 * Send the mail size, not forgetting lines are CRLF terminated. The
-	 * Google IMAP server is written strangely, so send the size as if
-	 * every CRLF was a CR if the server has XYZZY.
-	 */
-	count_lines(m, &total, &body);
-	maillen = m->size + total - 2;
-	if (fdata.capa & IMAP_CAPA_XYZZY) {
-		log_debug2("%s: adjusting size: actual %zu", a->name, maillen);
-		maillen = m->size;
-	}
 	if (fdata.capa & IMAP_CAPA_NOSPACE) {
 		if (imap_putln(a, "%s{%zu}", folder, maillen) != 0)
 			goto error;
@@ -246,6 +255,8 @@ retry:
 		if (imap_putln(a, "%s {%zu}", folder, maillen) != 0)
 			goto error;
 	}
+
+data:
 	switch (deliver_imap_waitappend(a, &fctx, io, &line)) {
 	case IMAP_TAG_ERROR:
 		if (line != NULL)


### PR DESCRIPTION
Hi.

These two changes allow fdm to save messages to iCloud via IMAP.

The first (9bce005) appears to address a bug in fdm itself. A message is to be terminated by a CRLF-pair, which must be accounted for by subtracting both the CR and LF from the message length. Only subtracting one character works fine with Dovecot, probably due to its forgiving nature, but iCloud's IMAP implementation is not as benign.

The second (14c04ba) mirrors those recently made in imap-common.c (17852bb), in that it deals with the fact that iCloud's IMAP implementation has never even heard of string continuations when it comes to mailbox names.

Kind regards, Willemijn Coene