### PR TITLE
Add OAuth 2.0 support for IMAP

### DIFF
--- a/MANUAL
+++ b/MANUAL
@@ -680,9 +680,12 @@ Examples of IMAP and IMAPS accounts include:
 
 By default, fdm prefers the CRAM-MD5 authentication method, since no passwords
 are sent in the clear.  If the server does not advertise CRAM-MD5 capability,
-the older LOGIN method is used.  For IMAPS connections (which use SSL), the
-LOGIN method is just as secure.  Either of these methods may be disabled with
-the 'no-cram-md5' and 'no-login' options.
+and 'oauthbearer' option is not passed the older LOGIN method is used.  For
+IMAPS connections (which use SSL), the LOGIN method is just as secure.  
+Either of these methods may be disabled with the 'no-cram-md5' and 'no-login'
+options.  If the server advertises OAUTHBEARER capability, 'oauthbearer'
+option will use OAuth 2.0 bearer tokens - passed via 'pass' keyword - as
+authentication method.
 
 The 'starttls' keyword may be added to an IMAP account to attemp STARTTLS after
 connection.

--- a/deliver-imap.c
+++ b/deliver-imap.c
@@ -197,6 +197,7 @@ deliver_imap_deliver(struct deliver_ctx *dctx, struct actitem *ti)
 	fdata.pass = data->pass;
 	fdata.nocrammd5 = data->nocrammd5;
 	fdata.nologin = data->nologin;
+	fdata.oauthbearer = data->oauthbearer;
 	memcpy(&fdata.server, &data->server, sizeof fdata.server);
 	fdata.io = io;
 	fdata.only = FETCH_ONLY_ALL;

--- a/deliver.h
+++ b/deliver.h
@@ -82,6 +82,7 @@ struct deliver_imap_data {
 	struct server	 server;
 	int		 nocrammd5;
 	int		 nologin;
+	int		 oauthbearer;
 	int		 starttls;
 
 	struct replstr	 folder;

--- a/fdm.conf.5
+++ b/fdm.conf.5
@@ -473,6 +473,7 @@ not be read from
 .Op Ic no-login
 .Op Ic starttls
 .Op Ic insecure
+.Op Ic oauthbearer
 .Xc
 .It Xo Ic imap Ic server Ar host
 .Op Ic port Ar port
@@ -492,6 +493,7 @@ not be read from
 .Op Ic no-cram-md5
 .Op Ic no-login
 .Op Ic insecure
+.Op Ic oauthbearer
 .Xc
 These define an IMAP or IMAPS account.
 The parameters are as for a POP3 or POP3S account, aside from the additional
@@ -530,6 +532,9 @@ after connection.
 .Ic insecure
 allows the use of insecure protocols, which currently includes SSLv2, SSLv3
 and TLS1.0.
+.Pp
+.Ic oauthbearer
+attempts to use OAuth 2.0 bearer token as authentication method.
 .It Xo Ic imap Ic pipe Ar command
 .Op Ar userpass
 .Op Ar folders

--- a/fetch.h
+++ b/fetch.h
@@ -204,6 +204,7 @@ struct fetch_imap_data {
 	int		 starttls;
 	int		 nocrammd5;
 	int		 nologin;
+	int		 oauthbearer;
 
 	u_int		 folder;
 	struct strings	*folders;
@@ -252,6 +253,7 @@ struct fetch_imap_mail {
 #define IMAP_CAPA_STARTTLS 0x4
 #define IMAP_CAPA_NOSPACE 0x8
 #define IMAP_CAPA_GMEXT 0x10
+#define IMAP_CAPA_AUTH_OAUTHBEARER 0x20
 
 /* fetch-maildir.c */
 extern struct fetch	 fetch_maildir;

--- a/imap-common.c
+++ b/imap-common.c
@@ -45,6 +45,7 @@ int	imap_state_connect(struct account *, struct fetch_ctx *);
 int	imap_state_capability1(struct account *, struct fetch_ctx *);
 int	imap_state_capability2(struct account *, struct fetch_ctx *);
 int	imap_state_starttls(struct account *, struct fetch_ctx *);
+int	imap_state_oauthbearer_auth(struct account *, struct fetch_ctx *);
 int	imap_state_cram_md5_auth(struct account *, struct fetch_ctx *);
 int	imap_state_login1(struct account *, struct fetch_ctx *);
 int	imap_state_login2(struct account *, struct fetch_ctx *);
@@ -303,6 +304,12 @@ imap_pick_auth(struct account *a, struct fetch_ctx *fctx)
 {
 	struct fetch_imap_data	*data = a->data;
 
+	/* Try OAUTHBEARER, if requested by user and if server supports it. */
+	if (data->oauthbearer && (data->capa & IMAP_CAPA_AUTH_OAUTHBEARER)) {
+		fctx->state = imap_state_oauthbearer_auth;
+		return (FETCH_AGAIN);
+	}
+
 	/* Try CRAM-MD5, if server supports it and user allows it. */
 	if (!data->nocrammd5 && (data->capa & IMAP_CAPA_AUTH_CRAM_MD5)) {
 		if (imap_putln(a,
@@ -417,6 +424,9 @@ imap_state_capability1(struct account *a, struct fetch_ctx *fctx)
 	if (strstr(line, "AUTH=CRAM-MD5") != NULL)
 		data->capa |= IMAP_CAPA_AUTH_CRAM_MD5;
 
+	if (strstr(line, "AUTH=OAUTHBEARER") != NULL)
+		data->capa |= IMAP_CAPA_AUTH_OAUTHBEARER;
+
 	/* Use XYZZY to detect Google brokenness. */
 	if (strstr(line, "XYZZY") != NULL)
 		data->capa |= IMAP_CAPA_XYZZY;
@@ -485,6 +495,31 @@ imap_state_starttls(struct account *a, struct fetch_ctx *fctx)
 
 	return (imap_pick_auth(a, fctx));
 }
+
+/* OAUTHBEARER auth state. */
+int
+imap_state_oauthbearer_auth(struct account *a, struct fetch_ctx *fctx)
+{
+	struct fetch_imap_data	*data = a->data;
+	char			*src, *b64;
+
+	xasprintf(&src,
+	    "n,a=%s,\001host=%s\001port=%d\001auth=Bearer %s\001\001",
+	    data->user, data->server.host, data->server.port, data->pass);
+	b64 = imap_base64_encode(src);
+	xfree(src);
+
+	if (imap_putln(a,
+	    "%u AUTHENTICATE OAUTHBEARER %s", ++data->tag, b64) != 0) {
+		xfree(b64);
+		return (FETCH_ERROR);
+	}
+	xfree(b64);
+
+	fctx->state = imap_state_pass;
+	return (FETCH_BLOCK);
+}
+
 
 /* CRAM-MD5 auth state. */
 int

--- a/lex.c
+++ b/lex.c
@@ -157,6 +157,7 @@ static const struct token tokens[] = {
 	{ "no-verify", TOKNOVERIFY },
 	{ "none", TOKNONE },
 	{ "not", TOKNOT },
+	{ "oauthbearer", TOKOAUTHBEARER },
 	{ "old-only", TOKOLDONLY },
 	{ "or", TOKOR },
 	{ "parallel-accounts", TOKPARALLELACCOUNTS },

--- a/parse.y
+++ b/parse.y
@@ -206,6 +206,7 @@ yyerror(const char *fmt, ...)
 %token TOKNOT
 %token TOKNOUIDL
 %token TOKNOVERIFY
+%token TOKOAUTHBEARER
 %token TOKOLDONLY
 %token TOKOR
 %token TOKPARALLELACCOUNTS
@@ -307,7 +308,7 @@ yyerror(const char *fmt, ...)
 %type  <fetch> fetchtype
 %type  <flag> cont not disabled keep execpipe writeappend compress verify
 %type  <flag> apop poptype imaptype nntptype nocrammd5 nologin uidl starttls
-%type  <flag> insecure
+%type  <flag> insecure oauthbearer
 %type  <localgid> localgid
 %type  <locks> lock locklist
 %type  <number> size time numv retrc expire
@@ -1217,7 +1218,7 @@ actitem: execpipe strv
 		 data->compress = $3;
 	 }
        | imaptype server userpassnetrc folder1 verify nocrammd5 nologin
-	 starttls insecure
+	 starttls insecure oauthbearer
 	 {
 		 struct deliver_imap_data	*data;
 
@@ -1258,6 +1259,7 @@ actitem: execpipe strv
 		 data->nologin = $7;
 		 data->starttls = $8;
 		 data->server.insecure = $9;
+		 data->oauthbearer = $10;
 	 }
        | TOKSMTP server from to
 	 {
@@ -2057,6 +2059,15 @@ insecure: TOKINSECURE
 		$$ = 0;
 	}
 
+oauthbearer: TOKOAUTHBEARER
+	   {
+		   $$ = 1;
+	   }
+	 | /* empty */
+	   {
+		   $$ = 0;
+	   }
+
 verify: TOKNOVERIFY
 	{
 		$$ = 0;
@@ -2259,7 +2270,7 @@ fetchtype: poptype server userpassnetrc poponly apop verify uidl starttls
 		   data->only = $5.only;
 	   }
 	 | imaptype server userpassnetrc folderlist imaponly verify nocrammd5
-	   nologin starttls insecure
+	   nologin starttls insecure oauthbearer
 	   {
 		   struct fetch_imap_data	*data;
 
@@ -2299,6 +2310,7 @@ fetchtype: poptype server userpassnetrc poponly apop verify uidl starttls
 		   data->nologin = $8;
 		   data->starttls = $9;
 		   data->server.insecure = $10;
+		   data->oauthbearer = $11;
 	   }
 	 | TOKIMAP TOKPIPE replstrv userpass folderlist imaponly
 	   {


### PR DESCRIPTION
This pull request add support for OAUTHBEARER (OAuth 2.0 bearer tokens,
as documented by [RFC 7628](https://tools.ietf.org/html/rfc7628)) for IMAP.

`oauthbearer` option can be passed to imap(s) server accounts in order to use
OAuth 2.0 if the IMAP server advertises OAUTHBEARER capability.
The token should be passed via `pass` (and can be easily dynamically
handled via a possible ad-hoc script using the `$(...)` syntax)


(The rest of the text in this PR are just notes used to create OAuth
client ID in order to use `oauthbearer` with a gmail account and can be
completely skipped if in hurry!)

For example, to use it for gmail accounts...

First an OAuth consent screen should be populated by visiting
<https://console.developers.google.com/>, creating/selecting a project - let's
say `email-access-oauth2`, set `User Type` to `External` and then set the
application name to e.g. `email-access-oauth2`.

Then authorization credentials should be created by visiting
<https://console.developers.google.com/apis/credentials>, selecting
`Create credentials -> OAuth client ID` and then we can can select
`Desktop app` as `Application type` and set `email-access-oauth2` as
`Name`.

After doing that we finally have a Client ID and Client Secret.

We can then use them with e.g.
[oauth2.py](https://github.com/google/gmail-oauth2-tools/blob/master/python/oauth2.py)
to generate a Refresh Token (assuming `<user>` is a gmail email, `<client_id>`
and `<client_secret>` corresponding the Client ID and Client Secret created in
the previous step):

````
% oauth2.py --user=<user> --client_id=<client_id> --client_secret=<client_secret> --generate_oauth2_token
````

This will also print an Authentication Token that can be passed to
`fdm` via `pass`, e.g.:

````
account "gmail" imaps
	server "imap.gmail.com"
	user "<user>"
	pass "<authentication_token>"
	folders {
		"INBOX"
	}
	oauthbearer
````

In order to easily refresh the token the `$(...)` syntax can be used in
order to run a separate script/program that just refresh an
Authentication Token when needed.