### PR TITLE
MANUAL typo: singular example

### DIFF
--- a/MANUAL
+++ b/MANUAL
@@ -190,7 +190,7 @@ The configuration file has the following general rules:
 - Lists are usually specified as 'singular item' or 'plural { item item }', for
   example: 'user "nicholas"', 'users { "nicholas" "bob" }'. The singular/plural
   distinction is not required, it is recommended only to aid readability:
-  'user { "nicholas "bob" }' is also accepted.
+  'user { "nicholas" "bob" }' is also accepted.
 - Regexps are specified as normal strings without additional adornment other
   than the "s (not wrapped in /s). All regexps are extended regexps. They are
   case insensitive by default but may be prefixed with the 'case' keyword to


### PR DESCRIPTION
Thank you for the extensive documentation!

Browsing today, spotted this syntax typo.