### PR TITLE
autoconf yacc bug workaround

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,8 @@ LDFLAGS="$LDFLAGS -L/usr/local/lib"
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_INSTALL
+AC_CHECK_PROG(YACC,[yacc],[yacc],[no])
+test "$YACC" == "no" && AC_MSG_ERROR("yacc not found")
 AC_PROG_YACC
 
 test "$sysconfdir" = '${prefix}/etc' && sysconfdir=/etc


### PR DESCRIPTION
I think #113 is actually an `automake` bug

https://github.com/stedolan/jq/issues/1093

https://savannah.gnu.org/support/?110266

I don't think the bug is really fixed yet. And I tried to switch to `AC_PROG_BISON` like in that bug report, but my toolchain didn't recognize the macro.

I am no `automake` expert but this PR solved it for me.

```
$ ./configure --prefix=$HOME/.local
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking for style of include used by make... GNU
checking dependency style of gcc... gcc3
checking for yacc... no
configure: error: "yacc not found"
```

Then after installing `bison`, which for me was `sudo apt install bison`

```
$ ./configure --prefix=$HOME/.local
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking for style of include used by make... GNU
checking dependency style of gcc... gcc3
checking for yacc... yacc
checking for bison... (cached) yacc
checking how to run the C preprocessor... gcc -E
...
```