### PR TITLE
RFC822 compliant received header

### DIFF
--- a/child-fetch.c
+++ b/child-fetch.c
@@ -652,7 +652,7 @@ fetch_enqueue(struct account *a, struct io *pio, struct mail *m)
 				rhost = conf.host_name;
 
 			error = insert_header(m, "received", "Received: by "
-			    "%.350s (%s " VERSION ", account \"%.350s\") \n\t%s\n\t%s",
+			    "%.350s (%s " VERSION ", account \"%.350s\")\n\t%s;\n\t%s",
 			    rhost, __progname, a->name, account_get_method(a), rtime);
 		}
 		if (error != 0)


### PR DESCRIPTION
According to [RFC822](https://www.rfc-editor.org/rfc/rfc822.html#section-4.1), there's a semicolon delimiter before the timestamp in the "received" header.

```
     received    =  "Received"    ":"            ; one per relay
                       ["from" domain]           ; sending host
                       ["by"   domain]           ; receiving host
                       ["via"  atom]             ; physical path
                      *("with" atom)             ; link/mail protocol
                       ["id"   msg-id]           ; receiver msg id
                       ["for"  addr-spec]        ; initial form
                        ";"    date-time         ; time received
```

There are many tools to see the difference; [here](https://toolbox.googleapps.com/apps/messageheader/) is one.