### PR TITLE
always initialize cause before return as error

### DIFF
--- a/io.c
+++ b/io.c
@@ -158,11 +158,10 @@ io_polln(struct io **iop, u_int n, struct io **rio, int timeout, char **cause)
 		xfree(pfds);
 
 		if (error == 0) {
-			if (timeout == 0) {
+			if (timeout == 0)
 				errno = EAGAIN;
-				return (-1);
-			}
-			errno = ETIMEDOUT;
+			else
+				errno = ETIMEDOUT;
 		}
 
 		if (errno == EINTR)


### PR DESCRIPTION
There is a bug on certain situations that cause remain uninitialized, fdm will show these lines on my OpenBSD:

```
remote: D(L[A\A]A^A_A[]L3$L;1
fdm(35648) in free(): bogus pointer (double free?) 0x501a4c67622
```

This patch is to initialize cause on my situation (I didn't find any other uninitialized cause)