### PR TITLE
Flag to keep mail unseen on the server for IMAP

### DIFF
--- a/MANUAL
+++ b/MANUAL
@@ -470,7 +470,7 @@ fdm fetches mail from a set of 'accounts', defined using the 'account'
 keyword. Each account has a name, a type, a number of account specific
 parameters and a couple of optional flags. The general form is:
 
-	account <name> [<users>] [disabled] <type> [<parameters>] [keep]
+	account <name> [<users>] [disabled] <type> [<parameters>] [keep] [unseen]
 
 The <name> item is a string by which the account is referred in filtering
 rules, log output and for the '-a' and '-x' command line options.
@@ -485,6 +485,10 @@ it is specified on the command line using the '-a' flag.
 The optional 'keep' keyword instructs fdm to keep all mail from this account
 (not delete it from the server) regardless of the result of the filtering
 rules.
+
+If the optional keyword 'unseen' is used, fdm will not mark all delivered 
+mails as seen. This can be useful for archiving purposes, so that the mail 
+status on the server is not changed, but backups can be created by fdm.
 
 The <type> item may be one of: 'pop3', 'pop3s', 'imap', 'imaps', 'stdin',
 'maildir' or 'maildirs'.
@@ -805,7 +809,8 @@ match account "news" {
 With POP3 and IMAP, fdm can be set up to fetch only new or old mail. For POP3
 this is achieved by recording the current state of the server in a cache file,
 which is updated as each mail is fetched. For IMAP it makes use of the 'seen'
-server flag which is updated by the server after each mail is fetched.
+server flag which is updated by the server after each mail is fetched. 
+The 'unseen' flag is not compatible with this functionality.
 
 These options are specified as in the following examples. For POP3:
 
@@ -1603,7 +1608,7 @@ This is because GMail is broken, see:
 In addition, GMail IMAP doesn't set the \Seen flag when mail is fetched with
 the UID FETCH BODY[] command (RFC3501 says that the "\Seen flag is implicitly
 set"). fdm works around this bug by setting the flag explicitly when mail is
-kept.
+kept (unless the 'unseen' flag is used). 
 
 %%% Why doesn't fdm run as a daemon?
 

--- a/fdm.h
+++ b/fdm.h
@@ -507,6 +507,7 @@ struct account {
 
 	int			 disabled;
 	int			 keep;
+	int          remain_unseen;
 
 	struct fetch		*fetch;
 	void			*data;

--- a/imap-common.c
+++ b/imap-common.c
@@ -956,7 +956,7 @@ imap_state_next(struct account *a, struct fetch_ctx *fctx)
 		 * GMail is broken and does not set the \Seen flag after mail
 		 * is fetched, so set it explicitly for kept mail.
 		 */
-		if (imap_putln(a, "%u UID STORE %u +FLAGS.SILENT (\\Seen)",
+		if (imap_putln(a, "%u UID STORE %u +FLAGS.SILENT ()",
 		    ++data->tag, ARRAY_FIRST(&data->kept)) != 0)
 			return (FETCH_ERROR);
 		ARRAY_REMOVE(&data->kept, 0);
@@ -1001,7 +1001,7 @@ imap_state_next(struct account *a, struct fetch_ctx *fctx)
 
 	/* Fetch the next mail. */
 	if (imap_putln(a, "%u "
-	    "UID FETCH %u BODY[]",++data->tag, ARRAY_FIRST(&data->wanted)) != 0)
+	    "UID FETCH %u BODY.PEEK[]",++data->tag, ARRAY_FIRST(&data->wanted)) != 0)
 		return (FETCH_ERROR);
 	fctx->state = imap_state_body;
 	return (FETCH_BLOCK);

--- a/imap-common.c
+++ b/imap-common.c
@@ -956,9 +956,16 @@ imap_state_next(struct account *a, struct fetch_ctx *fctx)
 		 * GMail is broken and does not set the \Seen flag after mail
 		 * is fetched, so set it explicitly for kept mail.
 		 */
-		if (imap_putln(a, "%u UID STORE %u +FLAGS.SILENT ()",
-		    ++data->tag, ARRAY_FIRST(&data->kept)) != 0)
-			return (FETCH_ERROR);
+		if (a->remain_unseen) {
+			if (imap_putln(a, "%u UID STORE %u +FLAGS.SILENT ()",
+				++data->tag, ARRAY_FIRST(&data->kept)) != 0)
+				return (FETCH_ERROR);
+		else {
+			if (imap_putln(a, "%u UID STORE %u +FLAGS.SILENT (\\Seen)",
+				++data->tag, ARRAY_FIRST(&data->kept)) != 0)
+				return (FETCH_ERROR);
+
+		}
 		ARRAY_REMOVE(&data->kept, 0);
 		fctx->state = imap_state_commit;
 		return (FETCH_BLOCK);
@@ -999,10 +1006,16 @@ imap_state_next(struct account *a, struct fetch_ctx *fctx)
 		return (FETCH_BLOCK);
 	}
 
-	/* Fetch the next mail. */
-	if (imap_putln(a, "%u "
-	    "UID FETCH %u BODY.PEEK[]",++data->tag, ARRAY_FIRST(&data->wanted)) != 0)
-		return (FETCH_ERROR);
+	if (a->remain_unseen) {
+		/* Fetch the next mail. */
+		if (imap_putln(a, "%u "
+			"UID FETCH %u BODY.PEEK[]",++data->tag, ARRAY_FIRST(&data->wanted)) != 0)
+			return (FETCH_ERROR);
+		} else {
+			if (imap_putln(a, "%u "
+			"UID FETCH %u BODY[]",++data->tag, ARRAY_FIRST(&data->wanted)) != 0)
+			return (FETCH_ERROR);
+	}
 	fctx->state = imap_state_body;
 	return (FETCH_BLOCK);
 }

--- a/imap-common.c
+++ b/imap-common.c
@@ -960,11 +960,10 @@ imap_state_next(struct account *a, struct fetch_ctx *fctx)
 			if (imap_putln(a, "%u UID STORE %u +FLAGS.SILENT ()",
 				++data->tag, ARRAY_FIRST(&data->kept)) != 0)
 				return (FETCH_ERROR);
-		else {
+		} else {
 			if (imap_putln(a, "%u UID STORE %u +FLAGS.SILENT (\\Seen)",
 				++data->tag, ARRAY_FIRST(&data->kept)) != 0)
 				return (FETCH_ERROR);
-
 		}
 		ARRAY_REMOVE(&data->kept, 0);
 		fctx->state = imap_state_commit;

--- a/lex.c
+++ b/lex.c
@@ -197,6 +197,7 @@ static const struct token tokens[] = {
 	{ "total-size", TOKTOTALSIZE },
 	{ "unmatched", TOKUNMATCHED },
 	{ "unmatched-mail", TOKIMPLACT },
+	{ "unseen", TOKUNSEEN },
 	{ "user", TOKUSER },
 	{ "users", TOKUSERS },
 	{ "value", TOKVALUE },

--- a/parse.y
+++ b/parse.y
@@ -176,6 +176,7 @@ yyerror(const char *fmt, ...)
 %token TOKINSECURE
 %token TOKINVALID
 %token TOKKEEP
+%token TOKUNSEEN
 %token TOKKEY
 %token TOKKILOBYTES
 %token TOKLMTP
@@ -309,7 +310,7 @@ yyerror(const char *fmt, ...)
 %type  <expritem> expritem
 %type  <exprop> exprop
 %type  <fetch> fetchtype
-%type  <flag> cont not disabled keep execpipe writeappend compress verify
+%type  <flag> cont not disabled keep unseen execpipe writeappend compress verify
 %type  <flag> apop poptype imaptype nntptype nocrammd5 noplain nologin uidl
 %type  <flag> starttls insecure oauthbearer xoauth2
 %type  <localgid> localgid
@@ -1038,6 +1039,15 @@ not: TOKNOT
       }
 
 keep: TOKKEEP
+      {
+	      $$ = 1;
+      }
+    | /* empty */
+      {
+	      $$ = 0;
+      }
+
+unseen: TOKUNSEEN
       {
 	      $$ = 1;
       }
@@ -2458,7 +2468,7 @@ fetchtype: poptype server userpassnetrc poponly apop verify uidl starttls
 		   data->server.ai = NULL;
 	   }
 
-account: TOKACCOUNT replstrv disabled users fetchtype keep
+account: TOKACCOUNT replstrv disabled users fetchtype keep unseen
 	 {
 		 struct account		*a;
 		 char			*su, desc[DESCBUFSIZE];
@@ -2473,6 +2483,7 @@ account: TOKACCOUNT replstrv disabled users fetchtype keep
 		 a = xcalloc(1, sizeof *a);
 		 strlcpy(a->name, $2, sizeof a->name);
 		 a->keep = $6;
+		 a->remain_unseen = $7;
 		 a->disabled = $3;
 		 a->users = $4;
 		 a->fetch = $5.fetch;


### PR DESCRIPTION
This adds the optional flag 'unseen' to the `account` sections allowing these accounts to keep mail as unseen on the server if IMAP is used. 
This is helpful in the instance that fdm is used as a backup solution that should therefor not modify the state of mail on the server.

This is implemented by using the IMAP command `BODY.PEEK[]` instead of `BODY[]`. The consequence of this is that new mail can not be distinguished from old mail anymore. 