### PR TITLE
Implement XDG base directory compliance

### DIFF
--- a/fdm.h
+++ b/fdm.h
@@ -52,9 +52,11 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
-#define CHILDUSER	"_fdm"
-#define CONFFILE	".fdm.conf"
-#define LOCKFILE	".fdm.lock"
+#define CHILDUSER		"_fdm"
+#define CONFFILE		"fdm.conf"
+#define LOCKFILE		"fdm.lock"
+#define CONFFILE_HOME	"." CONFFILE
+#define LOCKFILE_HOME	"." LOCKFILE
 #define DEFLOCKTIMEOUT	10
 #define MAXQUEUEVALUE	50
 #define DEFMAILQUEUE	2


### PR DESCRIPTION
Relevant issue: https://github.com/nicm/fdm/issues/96

This patch implements support for the XDG base directory specification.  This will not affect existing user configurations, but instead extends fdm to allow the user to specify an fdm.conf file in their $XDG_CONFIG_HOME directory (often ~/.config).  fdm now also will store it's fdm.lock lock file in $XDG_RUNTIME_DIR (e.g. /tmp/XXXX.runtime-dir.XXX) if it is set, and if not, will use the old behaviour of storing the lock file in the home directory.

The patch does not modify the behaviour of other "temporary files"--they are still stored in /tmp or under $TMPDIR like before.